### PR TITLE
Update to make plugin work with GoCD 17.1 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <go.version>14.4.0</go.version>
+        <go.version>16.12.0</go.version>
     </properties>
 
     <dependencies>
@@ -20,6 +20,11 @@
             <artifactId>go-plugin-api</artifactId>
             <version>${go.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>cd.go.plugin</groupId>
+            <artifactId>gocd-package-material-plugin-shim</artifactId>
+            <version>${go.version}</version>
         </dependency>
 
         <dependency>

--- a/src/com/tw/go/plugin/material/artifactrepository/deb/DebArtifactRepositoryMaterial.java
+++ b/src/com/tw/go/plugin/material/artifactrepository/deb/DebArtifactRepositoryMaterial.java
@@ -5,7 +5,6 @@ import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterial
 import com.tw.go.plugin.material.artifactrepository.deb.config.DebRepositoryConfiguration;
 import com.tw.go.plugin.material.artifactrepository.deb.poller.DebRepositoryPoller;
 
-@Extension
 public class DebArtifactRepositoryMaterial implements PackageMaterialProvider {
 
     public DebRepositoryConfiguration getConfig() {

--- a/src/com/tw/go/plugin/material/artifactrepository/deb/NewPackageMaterialProvider.java
+++ b/src/com/tw/go/plugin/material/artifactrepository/deb/NewPackageMaterialProvider.java
@@ -1,0 +1,33 @@
+package com.tw.go.plugin.material.artifactrepository.deb;
+
+import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
+import com.thoughtworks.go.plugin.api.GoPlugin;
+import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
+import com.thoughtworks.go.plugin.api.annotation.Extension;
+import com.thoughtworks.go.plugin.api.exceptions.UnhandledRequestTypeException;
+import com.thoughtworks.go.plugin.api.material.packagerepository.shim.ReplacementProvider;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+@Extension
+public class NewPackageMaterialProvider implements GoPlugin {
+    private ReplacementProvider replacementProvider;
+
+    public NewPackageMaterialProvider() {
+        replacementProvider = new ReplacementProvider(new DebArtifactRepositoryMaterial());
+    }
+
+    @Override
+    public GoPluginApiResponse handle(GoPluginApiRequest goPluginApiRequest) throws UnhandledRequestTypeException {
+        return replacementProvider.handle(goPluginApiRequest);
+    }
+
+    @Override
+    public GoPluginIdentifier pluginIdentifier() {
+        return replacementProvider.pluginIdentifier();
+    }
+
+    @Override
+    public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
+    }
+}

--- a/src/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrl.java
+++ b/src/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrl.java
@@ -24,7 +24,7 @@ public class RepoUrl {
     static {
         map.put("file", fileBasedConnectionChecker);
         map.put("http", httpConnectionChecker);
-        //map.put("https", httpConnectionChecker);
+        map.put("https", httpConnectionChecker);
     }
 
     public RepoUrl(String url, String user, String password) {

--- a/test/com/tw/go/plugin/material/artifactrepository/deb/config/DebRepositoryConfigurationTest.java
+++ b/test/com/tw/go/plugin/material/artifactrepository/deb/config/DebRepositoryConfigurationTest.java
@@ -131,7 +131,7 @@ public class DebRepositoryConfigurationTest {
         try {
             debRepositoryConfiguration.testConnection(packageConfigurations, repositoryConfigurations);
         } catch (Exception e) {
-            fail("");
+            fail("Got exception: " + e.getMessage());
         }
     }
 

--- a/test/com/tw/go/plugin/material/artifactrepository/deb/connection/HttpConnectionCheckerTest.java
+++ b/test/com/tw/go/plugin/material/artifactrepository/deb/connection/HttpConnectionCheckerTest.java
@@ -6,20 +6,21 @@ import org.junit.Test;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.matchers.JUnitMatchers.containsString;
 
 public class HttpConnectionCheckerTest {
     @Test
     public void shouldNotThrowExceptionIfCheckConnectionToTheRepoPasses() {
-        new HttpConnectionChecker().checkConnection("http://in.archive.ubuntu.com/ubuntu/dists/saucy/main/binary-amd64/", new Credentials(null, null));
+        new HttpConnectionChecker().checkConnection("http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64/", new Credentials(null, null));
     }
 
     @Test
     public void shouldFailCheckConnectionToTheRepoWhenUrlIsNotReachable() {
         try {
-            new HttpConnectionChecker().checkConnection("http://sifystdgobgr101.thoughtworks.com:8080/tfs/1.txt", new Credentials(null, null));
+            new HttpConnectionChecker().checkConnection("https://build.go.cd/go/api/support", new Credentials(null, null));
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("HTTP/1.1 401 Unauthorized"));
+            assertThat(e.getMessage(), containsString("HTTP/1.1 401"));
         }
     }
 }

--- a/test/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrlTest.java
+++ b/test/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrlTest.java
@@ -30,6 +30,7 @@ public class RepoUrlTest {
         assertRepositoryUrlValidation("http://correct.com/url", null, null, new ArrayList<ValidationError>(), true);
         assertRepositoryUrlValidation("file:///foo.bar", null, null, new ArrayList<ValidationError>(), true);
         assertRepositoryUrlValidation("file:///foo.bar", "user", "password", asList(new ValidationError(REPO_URL, "File protocol does not support username and/or password.")), false);
+        assertRepositoryUrlValidation("https://correct.com/url", null, null, new ArrayList<ValidationError>(), true);
     }
 
     @Test
@@ -82,10 +83,10 @@ public class RepoUrlTest {
     @Test
     public void shouldFailCheckConnectionToTheRepoWhenHttpUrlIsNotReachable() {
         try {
-            new RepoUrl("http://sifystdgobgr101.thoughtworks.com:8080/tfs/", null, null).checkConnection();
+            new RepoUrl("https://build.go.cd/go/api/support", null, null).checkConnection();
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("HTTP/1.1 401 Unauthorized"));
+            assertThat(e.getMessage(), containsString("HTTP/1.1 401"));
         }
     }
 
@@ -101,8 +102,8 @@ public class RepoUrlTest {
 
     @Test
     public void shouldNotThrowExceptionIfCheckConnectionToTheRepoPasses() {
-        new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/saucy/main/binary-amd64/", null, null).checkConnection();
-        new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/saucy/main/binary-amd64", null, null).checkConnection();
+        new RepoUrl("http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64/", null, null).checkConnection();
+        new RepoUrl("http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64", null, null).checkConnection();
     }
 
     @Test


### PR DESCRIPTION
Using the [plugin shim](https://github.com/gocd-contrib/gocd-package-material-plugin-shim) to upgrade this plugin, so that it works with 17.1. Without this change, this plugin will stop working from GoCD 17.1 onwards.