### PR TITLE
Upgrade to newer http client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,23 +40,9 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.0.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -68,7 +54,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -105,8 +91,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/test/com/tw/go/plugin/material/artifactrepository/deb/connection/HttpConnectionCheckerTest.java
+++ b/test/com/tw/go/plugin/material/artifactrepository/deb/connection/HttpConnectionCheckerTest.java
@@ -3,7 +3,6 @@ package com.tw.go.plugin.material.artifactrepository.deb.connection;
 import com.tw.go.plugin.material.artifactrepository.deb.model.Credentials;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.matchers.JUnitMatchers.containsString;
@@ -17,7 +16,7 @@ public class HttpConnectionCheckerTest {
     @Test
     public void shouldFailCheckConnectionToTheRepoWhenUrlIsNotReachable() {
         try {
-            new HttpConnectionChecker().checkConnection("https://build.go.cd/go/api/support", new Credentials(null, null));
+            new HttpConnectionChecker().checkConnection("https://build.gocd.io/go/api/support", new Credentials(null, null));
             fail("should fail");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString("HTTP/1.1 401"));

--- a/test/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrlTest.java
+++ b/test/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrlTest.java
@@ -13,9 +13,9 @@ import java.util.List;
 import static com.tw.go.plugin.material.artifactrepository.deb.constants.Constants.REPO_URL;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.junit.internal.matchers.StringContains.containsString;
 
 public class RepoUrlTest {
     @Test
@@ -83,7 +83,7 @@ public class RepoUrlTest {
     @Test
     public void shouldFailCheckConnectionToTheRepoWhenHttpUrlIsNotReachable() {
         try {
-            new RepoUrl("https://build.go.cd/go/api/support", null, null).checkConnection();
+            new RepoUrl("https://build.gocd.io/go/api/support", null, null).checkConnection();
             fail("should fail");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString("HTTP/1.1 401"));


### PR DESCRIPTION
* Change domain name to build.gocd.io.

The status in the tests would have been 301 instead of 401 if the domain name wasn't changed. 